### PR TITLE
Fix R processing of dashed file names

### DIFF
--- a/prok_tuxedo.py
+++ b/prok_tuxedo.py
@@ -338,16 +338,18 @@ def setup(genome_list, condition_dict, parameters, output_dir, job_data):
                 if "srr_accession" in r:
                     srr_id = r["srr_accession"] 
                     meta_file = os.path.join(target_dir,srr_id+"_meta.txt")
-                    subprocess.check_call(["p3-sra","--gzip","--out",target_dir,"--metadata-file", meta_file, "--id",srr_id])
+                    subprocess.check_call(["p3-sra","--out",target_dir,"--metadata-file", meta_file, "--id",srr_id])
                     with open(meta_file) as f:
                         job_meta = json.load(f)
                         files = job_meta[0].get("files",[])
                         for i,f in enumerate(files):
-                            if f.endswith("_2.fastq.gz"):
+                            if f.endswith("_2.fastq"):
                                 r["read2"]=os.path.join(target_dir, f)
-                            if f.endswith("_1.fastq.gz"):
+                            elif f.endswith("_1.fastq"):
                                 r["read1"]=os.path.join(target_dir, f)
-                            if f.endswith("fastqc.html"):
+                            elif f.endswith(".fastq"):
+                                r["read1"]=os.path.join(target_dir, f)
+                            elif f.endswith("fastqc.html"):
                                 r["fastqc"].append(os.path.join(target_dir, f))
                     
 

--- a/src/generate_heatmaps.R
+++ b/src/generate_heatmaps.R
@@ -32,21 +32,21 @@ library(graphics)
 ###TODO: add units to the heatmap (TPM, TPKM, etc)
 
 #create a heatmap with normalized expression 
-counts.mtx <- read.table(counts.file,sep=count_sep,header=T,row.names=1,stringsAsFactors=FALSE)
-metadata <- read.table(metadata.file,sep="\t",header=T,stringsAsFactors=FALSE)
-genes.list <- read.table(genes.file,stringsAsFactors=FALSE)
+counts.mtx <- read.table(counts.file,sep=count_sep,header=T,row.names=1,stringsAsFactors=FALSE,check.names=FALSE)
+metadata <- read.table(metadata.file,sep="\t",header=T,stringsAsFactors=FALSE,check.names=FALSE)
+genes.list <- read.table(genes.file,stringsAsFactors=FALSE,check.names=FALSE)
 colnames(genes.list) <- c("Genes")
 #check for if specialty genes were found for this genome: if not don't include in heatmap
 if (specialty_genes.file == "NONE") {
     specialty.genes <- NULL
 } else {
-    specialty.genes <- read.table(specialty_genes.file,header=T,sep="\t")
+    specialty.genes <- read.table(specialty_genes.file,header=T,sep="\t",check.names=FALSE)
 }
 #check for if subsystem genes were found for this genome: if not don't include in heatmap
 if (subsystem.file == "NONE") {
     subsystem.map <- NULL
 } else {
-    subsystem.map <- read.table(subsystem.file,sep="\t",header=T,stringsAsFactors=FALSE)
+    subsystem.map <- read.table(subsystem.file,sep="\t",header=T,stringsAsFactors=FALSE,check.names=FALSE)
 }
 
 #Usually doesn't happen, but sometimes for host there heatmap genes and counts table do not share all genes

--- a/src/run_deseq2.R
+++ b/src/run_deseq2.R
@@ -41,10 +41,10 @@ library(gridExtra,quietly=TRUE)
 library(svglite)
 
 #Load counts table and metadata table 
-count.mtx <- read.table(counts.file,sep=count_sep,header=T,row.names=1,stringsAsFactors=FALSE)
+count.mtx <- read.table(counts.file,sep=count_sep,header=T,row.names=1,stringsAsFactors=FALSE,check.names=FALSE)
 rownames(count.mtx) = gsub("gene-","",rownames(count.mtx))
 rownames(count.mtx) = gsub("rna-","",rownames(count.mtx))
-metadata <- read.table(metadata.file,sep=meta_sep,header=T,stringsAsFactors=FALSE)
+metadata <- read.table(metadata.file,sep=meta_sep,header=T,stringsAsFactors=FALSE, check.names=FALSE)
 
 #calculate png width and height
 png_width = 600
@@ -67,7 +67,7 @@ for (i in 5:length(args))
     #Subset data on current contrast
     curr_contrast = unlist(strsplit(args[i],","))
     #curr_contrast = gsub("-","_",curr_contrast)
-    curr.metadata = subset(metadata,(subset=Condition==curr_contrast[1])|(subset=Condition==curr_contrast[2]))
+    curr.metadata = subset(metadata,(Condition==curr_contrast[1])|(Condition==curr_contrast[2]))
     curr.count.mtx = count.mtx[,curr.metadata$Sample] 
     #Remove all zero rows and add pseudocount to genes: Will not work for some samples otherwise
     curr.count.mtx = curr.count.mtx[rowSums(curr.count.mtx) != 0,]


### PR DESCRIPTION
R read_table converts column names to lose dashes. A problem for samples named after filenames...
Ultimately there should be a mapping / legend from filename to something like \<ConditionName\>_\<SampleNumber\> not only for the sake of processing but for the images as well.
Also, there could be "sample alias" field on the input form.